### PR TITLE
add missing tip.fog.est item

### DIFF
--- a/man/OUwie.Rd
+++ b/man/OUwie.Rd
@@ -57,6 +57,7 @@ For models that allow \eqn{\alpha}{alpha} and \eqn{\sigma^2}{sigma^2} to vary (i
 \item{$solution}{a matrix containing the maximum likelihood estimates of \eqn{\alpha}{alpha} and \eqn{\sigma^2}{sigma^2}.}
 \item{$theta}{a matrix containing the maximum likelihood estimates of \eqn{\theta}{theta} and its standard error.}
 \item{$solution.se}{a matrix containing the approximate standard errors of \eqn{\alpha}{alpha} and \eqn{\sigma^2}{sigma^2}. The standard error is calculated as the diagonal of the inverse of the Hessian matrix.}
+\item{$tip.fog.est}{indicates value of the measurement error if it was estimated from the data.}
 \item{$tot.state}{A vector of names for the different regimes}
 \item{$index.mat}{The indices of the parameters being estimated are returned. The numbers correspond to the row in the \code{eigvect} and can useful for identifying the parameters that are causing the objective function to be at a saddlepoint (see Details).}
 \item{$simmap.tree}{A logical indicating whether the input phylogeny is a SIMMAP formatted tree.}


### PR DESCRIPTION
The returned `tip.fog.est` is currently only documented in [man/OUwie.dredge.Rd](https://github.com/thej022214/OUwie/blob/cf80ba02156db000f5d2e15683112e79f6e0ae4e/man/OUwie.dredge.Rd). This pull request simply adds it to [man/OUwie.Rd](https://github.com/thej022214/OUwie/blob/cf80ba02156db000f5d2e15683112e79f6e0ae4e/man/OUwie.Rd), as it is also returned by this function if `tip.fog` is specified.