### PR TITLE
added fix for counting shifts in check.identify

### DIFF
--- a/R/check.identify.R
+++ b/R/check.identify.R
@@ -21,7 +21,8 @@ check.identify <- function(phy, data, simmap.tree=FALSE, quiet=FALSE){
         if(simmap.tree==TRUE){
             regimeindex <- colnames(phy$mapped.edge)
             currentmap <- phy$maps[[i]]
-            if(length(currentmap > 1)){
+            if(length(currentmap) > 1){
+              print("hit")
                 shift.number <- shift.number + 1
                 regime_shifts[shift.number] <- i
             }
@@ -82,7 +83,7 @@ check.identify.dredge <- function(phy, data, simmap.tree=FALSE, get.penalty=FALS
         if(simmap.tree==TRUE){
             regimeindex <- colnames(phy$mapped.edge)
             currentmap <- phy$maps[[i]]
-            if(length(currentmap > 1)){
+            if(length(currentmap) > 1){
                 shift.number <- shift.number + 1
                 regime_shifts[[shift.number]] <- i
             }


### PR DESCRIPTION
I have been playing around with a simmap tree that was not flagged in `OUwie` as not idenitifiable, however, all regime weights were identical. After looking at the simmap, all regimes form connected subtrees and it should get flagged as such. 

For simmaps, it looks like rather than counting if there are shifts on a branch, it was comparing if time spent in a regime was greater than 1 and thus counting more shifts than it should. I am happy to share the tree I was working on if useful. Thanks!